### PR TITLE
docs: fix README recommendation spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ This repo contains three files of IR codes:
 2. `PixMob_all_colors.ir`: Codes to set bracelets to every possible color (with what reverse-engineering has found so far), but without the fade effects
 3. `PixMob_special.ir`: Special codes to do things like random colors, enter motion sensitive mode on very old PixMob bracelets, and more. It is easy to mess up bracelets using these codes because some have persistent effects. I don't recommend using this unless you are willing to mess up your bracelet and require a difficult reset.
 
-I reccomend `PixMob_main.ir` as a starting place.
+I recommend `PixMob_main.ir` as a starting place.
 
 ### How to use
 Copy one of the IR code files (start with `PixMob_main.ir`) into the `infrared` folder of your Flipper Zero SD card. You can do this either with qFlipper or by taking out the SD card, mounting it on your computer, moving the files, and putting the SD card back into the Flipper. 
 From there, look under your "Saved Remotes" in the "Infrared" app for the relevant new remote and try sending some signals!
-


### PR DESCRIPTION
## Summary
- Fixes a README spelling typo: `reccomend` -> `recommend` in the PixMob_main.ir recommendation sentence.

## Validation
- `rg -n "reccomend|recommend|PixMob_main|starting place" README.md`
- `git diff --check`

No runtime tests were run because this is README prose only and does not change code, commands, generated output, configuration, or IR data files.